### PR TITLE
fix: alt lang links not printing closing tag

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -882,17 +882,15 @@ class Plugin {
 		LogService::legacy_log( $widget_args, 4 );
 		foreach ( $widget_args as $lang ) {
 			if ( ! $lang['active'] ) {
-				echo '<link rel="alternate" hreflang="' . $lang['isocode'] . '" href="';
+				$url = $lang['url'];
 				if ( $this->options->full_rel_alternate ) {
 					$current_url = ( is_ssl() ? 'https://' : 'http://' ) . Utilities::get_clean_server_var( 'HTTP_HOST' ) . Utilities::get_clean_server_var( 'REQUEST_URI' );
 					$url         = Utilities::rewrite_url_lang_param( $current_url, $this->home_url, $this->enable_permalinks_rewrite, $lang['isocode'], $this->edit_mode );
 					if ( $this->options->is_default_language( $lang['isocode'] ) ) {
 						$url = Utilities::cleanup_url( $url, $this->home_url );
 					}
-					echo $url;
-				} else {
-					echo $lang['url'];
 				}
+				echo "<link rel='alternate' hreflang='{$lang['isocode']}' href='$url' />";
 			}
 		}
 	}


### PR DESCRIPTION
public function add_rel_alternate() 

Previously this function echoed out the link element in 3 separate statements 

1. the beginning of the rel='alternate' <link>
2. the href attribute
3. then the closing tag 

A previous update removed the step that printed the closing tag, leading to malformed HTML on the sites using this plugin. 

I did a small refactor so instead we first calculate the url for the href attribute and then use a single echo to print the <link> correctly